### PR TITLE
Changed href to routerLink for prev and next tutorials

### DIFF
--- a/src/app/tutorial/chapters/appendixA/appendixA.component.html
+++ b/src/app/tutorial/chapters/appendixA/appendixA.component.html
@@ -156,10 +156,10 @@ EndSub</code></pre>
     &nbsp;
   </p>
   <div>
-    <a style="float: left;" href="/tutorials/chapter11" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter11" title="Previous Chapter"
       >Previous Chapter: Events</a
     >
-    <a style="float: right;" href="/tutorials/appendixB" title="Appendix"
+    <a style="float: right;" routerLink="../appendixB" title="Appendix"
       >Appendix B: Colors</a
     >
   </div>

--- a/src/app/tutorial/chapters/appendixB/appendixB.component.html
+++ b/src/app/tutorial/chapters/appendixB/appendixB.component.html
@@ -642,7 +642,7 @@
   </table>
   <br />
   <div>
-      <a style="float: left;" href="/tutorials/appendixA" title="Previous Appendix">Appendix A: Samples</a>
-      <a style="float: right;" href="/tutorials/" title="Back To Tutorials Page">Back To Tutorials Page</a>
+      <a style="float: left;" routerLink = '../appendixA' title="Previous Appendix">Appendix A: Samples</a>
+      <a style="float: right;" routerLink = '../' title="Back To Tutorials Page">Back To Tutorials Page</a>
   </div>
 </div>

--- a/src/app/tutorial/chapters/chapter1/chapter1.component.html
+++ b/src/app/tutorial/chapters/chapter1/chapter1.component.html
@@ -1,6 +1,6 @@
 <div class="container mrg-top20 sb-main-container">
   <div class="col-xs-9 sb-main-cont-left">
-    <h2>An Introduction</h2>
+    <h2 name='chapterTitle'>An Introduction</h2>
     <h3><a name="Small_basic_intro"></a>Small Basic and Programming</h3>
     <p>
       Computer Programming is defined as the process of creating computer
@@ -211,10 +211,8 @@
       to see the full Curriculum or check out the Tutorials page below
     </p>
     <div>
-      <a style="float:left;" href="/tutorials/" title="Tutorials">Tutorials</a>
-      <a style="float:right;" href="/tutorials/chapter2" title="Next Chapter"
-        >Next Chapter: Understanding Our First Program</a
-      >
+      <a style="float:left;" routerLink="../" title="Tutorials">Tutorials</a>
+      <a routerLink="../chapter2" name="chapterTitle" style="float:right;"  title="Next Chapter">Next Chapter: Understanding Our First Program</a>
     </div>
   </div>
   <div class="col-xs-3 sb-main-cont-right">

--- a/src/app/tutorial/chapters/chapter1/chapter1.component.html
+++ b/src/app/tutorial/chapters/chapter1/chapter1.component.html
@@ -1,6 +1,6 @@
 <div class="container mrg-top20 sb-main-container">
   <div class="col-xs-9 sb-main-cont-left">
-    <h2 name='chapterTitle'>An Introduction</h2>
+    <h2>An Introduction</h2>
     <h3><a name="Small_basic_intro"></a>Small Basic and Programming</h3>
     <p>
       Computer Programming is defined as the process of creating computer
@@ -212,7 +212,7 @@
     </p>
     <div>
       <a style="float:left;" routerLink="../" title="Tutorials">Tutorials</a>
-      <a routerLink="../chapter2" name="chapterTitle" style="float:right;"  title="Next Chapter">Next Chapter: Understanding Our First Program</a>
+      <a routerLink="../chapter2" style="float:right;"  title="Next Chapter">Next Chapter: Understanding Our First Program</a>
     </div>
   </div>
   <div class="col-xs-3 sb-main-cont-right">

--- a/src/app/tutorial/chapters/chapter10/chapter10.component.html
+++ b/src/app/tutorial/chapters/chapter10/chapter10.component.html
@@ -367,10 +367,10 @@ EndFor</code></pre>
     <strong>Figure 10.8 - Keeping track of boxes in the grid</strong>
   </p>
   <div>
-    <a style="float:left;" href="/tutorials/chapter9" title="Previous Chapter"
+    <a style="float:left;" routerLink="../chapter9" title="Previous Chapter"
       >Previous Chapter: Subroutines</a
     >
-    <a style="float:right;" href="/tutorials/chapter11" title="Next Chapter"
+    <a style="float:right;" routerLink= "../chapter11" title="Next Chapter"
       >Next Chapter: Events</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter11/chapter11.component.html
+++ b/src/app/tutorial/chapters/chapter11/chapter11.component.html
@@ -209,10 +209,10 @@ EndSub</code></pre>
 
   <p>&nbsp;</p>
   <div>
-    <a style="float: left;" href="/tutorials/chapter10" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter10" title="Previous Chapter"
       >Previous Chapter: Arrays</a
     >
-    <a style="float: right;" href="/tutorials/appendixA" title="Appendix"
+    <a style="float: right;" routerLink="../appendixA" title="Appendix"
       >Appendix: Samples</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter2/chapter2.component.html
+++ b/src/app/tutorial/chapters/chapter2/chapter2.component.html
@@ -250,7 +250,7 @@
 <div class="cls_011"><span class="cls_011">DarkYellow</span></div>
 
 <div>
-  <a style="float: left;" routerLink="../chapter1" name="chapterTitle" title="Previous Chapter"
+  <a style="float: left;" routerLink="../chapter1" title="Previous Chapter"
     >Previous Chapter: Getting Started</a
   >
   <a style="float: right;" routerLink="../chapter3"  title="Next Chapter"

--- a/src/app/tutorial/chapters/chapter2/chapter2.component.html
+++ b/src/app/tutorial/chapters/chapter2/chapter2.component.html
@@ -1,4 +1,4 @@
-<div class="cls_004"><span class="cls_004">Chapter 2</span></div>
+<div class="cls_004"><span id='chapterTitle' class="cls_004">Chapter 2</span></div>
 <div class="cls_005">
   <span class="cls_005">Understanding Our First Program</span>
 </div>
@@ -250,10 +250,10 @@
 <div class="cls_011"><span class="cls_011">DarkYellow</span></div>
 
 <div>
-  <a style="float: left;" href="/tutorials/chapter1" title="Previous Chapter"
+  <a style="float: left;" routerLink="../chapter1" name="chapterTitle" title="Previous Chapter"
     >Previous Chapter: Getting Started</a
   >
-  <a style="float: right;" href="/tutorials/chapter3" title="Next Chapter"
+  <a style="float: right;" routerLink="../chapter3"  title="Next Chapter"
     >Next Chapter: Variables</a
   >
 </div>

--- a/src/app/tutorial/chapters/chapter3/chapter3.component.html
+++ b/src/app/tutorial/chapters/chapter3/chapter3.component.html
@@ -330,10 +330,10 @@ TextWindow.WriteLine(&quot;Temperature in Celsius is &quot; &#43; celsius)</code
   </div>
 
   <div>
-    <a style="float: left;" href="/tutorials/chapter2" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter2" title="Previous Chapter"
       >Previous Chapter: Branches</a
     >
-    <a style="float: right;" href="/tutorials/chapter4" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter4" title="Next Chapter"
       >Next Chapter: Conditions</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter4/chapter4.component.html
+++ b/src/app/tutorial/chapters/chapter4/chapter4.component.html
@@ -288,10 +288,10 @@ Goto begin</code></pre>
     </p>
   </div>
   <div>
-    <a style="float: left;" href="/tutorials/chapter3" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter3"  title="Previous Chapter"
       >Previous Chapter: Variables</a
     >
-    <a style="float: right;" href="/tutorials/chapter5" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter5" title="Next Chapter"
       >Next Chapter: Loops</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter5/chapter5.component.html
+++ b/src/app/tutorial/chapters/chapter5/chapter5.component.html
@@ -176,10 +176,10 @@ EndIf</code></pre>
     </p>
   </div>
   <div>
-    <a style="float: left;" href="/tutorials/chapter4" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter4"  title="Previous Chapter"
       >Previous Chapter: Conditions</a
     >
-    <a style="float: right;" href="/tutorials/chapter6" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter6" title="Next Chapter"
       >Next Chapter: Graphics</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter6/chapter6.component.html
+++ b/src/app/tutorial/chapters/chapter6/chapter6.component.html
@@ -324,10 +324,10 @@ GraphicsWindow.FillEllipse(100, 100, 100, 100)</code></pre>
   </div>
 
   <div>
-    <a style="float: left;" href="/tutorials/chapter5" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter5" title="Previous Chapter"
       >Previous Chapter: Loops</a
     >
-    <a style="float: right;" href="/tutorials/chapter7" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter7" title="Next Chapter"
       >Next Chapter: Shapes</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter7/chapter7.component.html
+++ b/src/app/tutorial/chapters/chapter7/chapter7.component.html
@@ -202,10 +202,10 @@ GraphicsWindow.SetPixel(x, y, color)</code></pre>
   </div>
 
   <div>
-    <a style="float: left;" href="/tutorials/chapter6" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter6" title="Previous Chapter"
       >Previous Chapter: Graphics</a
     >
-    <a style="float: right;" href="/tutorials/chapter8" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter8" title="Next Chapter"
       >Next Chapter: Turtle</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter8/chapter8.component.html
+++ b/src/app/tutorial/chapters/chapter8/chapter8.component.html
@@ -298,10 +298,10 @@ EndFor</code></pre>
     </p>
   </div>
   <div>
-    <a style="float: left;" href="/tutorials/chapter7" title="Previous Chapter"
+    <a style="float: left;" routerLink="../chapter7" title="Previous Chapter"
       >Previous Chapter: Shapes</a
     >
-    <a style="float: right;" href="/tutorials/chapter9" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter9" title="Next Chapter"
       >Next Chapter: Subroutines</a
     >
   </div>

--- a/src/app/tutorial/chapters/chapter9/chapter9.component.html
+++ b/src/app/tutorial/chapters/chapter9/chapter9.component.html
@@ -289,10 +289,10 @@ EndSub</code></pre>
   </div>
 
   <div>
-    <a style="float: left;" href="/tutorials/chapter8" title="Previous Chapter"
+    <a style="float: left;" routerLink= "../chapter8" title="Previous Chapter"
       >Previous Chapter: Turtle</a
     >
-    <a style="float: right;" href="/tutorials/chapter10" title="Next Chapter"
+    <a style="float: right;" routerLink="../chapter10" title="Next Chapter"
       >Next Chapter: Arrays</a
     >
   </div>


### PR DESCRIPTION
Changed the href to routerLinks  for next and prev tutorials.
 Looks like there was already the route-outlet, so didn't need to do any major change. 
Anchoring to title of the each tutorial still needs to be done to scroll to top of section after link is pressed.