### PR TITLE
Add accessible text to social media links

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -67,10 +67,10 @@
     </div>
     <div id="sidebar">
       <div class="socialMedia">
-        <a href="https://www.facebook.com/groups/smallbasic/" target="_blank" alt="Link to Small Basic Facebook page" class="fa fa-facebook"></a>
-        <a href="https://twitter.com/Small_Basic" target="_blank" alt="Link to Small Basic Twitter page" class="fa fa-twitter"></a>
-        <a href="https://www.youtube.com/channel/UCu725C2we0oPgrRbWVLWjkw" target="_blank" alt="Link to Small Basic YouTube page" class="fa fa-youtube"></a>
-        <a href="https://social.msdn.microsoft.com/Forums/en-US/home?forum=smallbasic" target="_blank" alt="Link to Microsoft Developer Network Small Basic forum" class="fa fa-windows"></a>
+        <a href="https://www.facebook.com/groups/smallbasic/" target="_blank" title="Link to Small Basic Facebook page" class="fa fa-facebook"></a>
+        <a href="https://twitter.com/Small_Basic" target="_blank" title="Link to Small Basic Twitter page" class="fa fa-twitter"></a>
+        <a href="https://www.youtube.com/channel/UCu725C2we0oPgrRbWVLWjkw" target="_blank" title="Link to Small Basic YouTube page" class="fa fa-youtube"></a>
+        <a href="https://social.msdn.microsoft.com/Forums/en-US/home?forum=smallbasic" target="_blank" title="Link to Microsoft Developer Network Small Basic forum" class="fa fa-windows"></a>
       </div>
       <div>
         <h2>Announcements</h2>


### PR DESCRIPTION
Fixes #66 

Changed the `alt` attribute on the four social media links to `title` (`alt` is [not supported](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) on `a`, but `title` is a [global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title)). 


The title is also visible in a tool tip on hover:
![image](https://user-images.githubusercontent.com/1752950/61814459-009b0000-adfd-11e9-8e9f-07613c0c82e3.png)

This change makes the home page Accessibility Insights FastPass automated checks clean.