### PR TITLE
Fix color contrast issue with tutorial download link

### DIFF
--- a/src/app/tutorial/chapters/chapter1/chapter1.component.html
+++ b/src/app/tutorial/chapters/chapter1/chapter1.component.html
@@ -86,7 +86,7 @@
         title="Download Small Basic"
         class="btn btn-primary download-sb"
       >
-        <h4>Download</h4></a
+        Download</a
       >
     </div>
     <p>This window will appear:</p>


### PR DESCRIPTION
Fixes #72 

The download link contained an H4 which was causing the link to be styled differently than other links. Since it doesn't make sense for a link to contain a header, removed the H4, and the link now looks like other links and there is no contrast issue on this page. (If there is an H4 on another page, that may exhibit the contrast issue, but that should be a separate issue/PR.)

Old appearance:
![image](https://user-images.githubusercontent.com/1752950/61816405-23c7ae80-ae01-11e9-9064-72313c373683.png)

New appearance:
![image](https://user-images.githubusercontent.com/1752950/61816486-51145c80-ae01-11e9-8bca-07e7196a5f33.png)
