### PR TITLE
Use darker green to fix two a11y contrast issues

### DIFF
--- a/src/app/programs/programs.component.css
+++ b/src/app/programs/programs.component.css
@@ -4,7 +4,7 @@
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
-  background-color: #6fa300;
+  background-color: #567d00;
   border: 1px solid;
   border-color: #357ebd;
   padding: 6px 12px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,7 +26,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    color: #689800; 
+    color: #567d00; 
 }
 
 #contentWrapper {


### PR DESCRIPTION
Fixes #76 and #77 

The green color used for headers meets more lenient contrast requirements for larger headers (H1, H2, H3) but for smaller text (H4) it fails the stricter requirements. Changed the color to match the similar but darker green used in docs navigation.

Also changed the green used in the "Check it out" buttons on featured programs to this same green to resolve color contrast issues there.

Home page after:
![image](https://user-images.githubusercontent.com/1752950/61819121-3349f600-ae07-11e9-9c0a-ca5668281929.png)

Featured programs after:
![image](https://user-images.githubusercontent.com/1752950/61819155-465cc600-ae07-11e9-9248-8e119f794b7c.png)
