### PR TITLE
Change text color in color list to pass contrast

### DIFF
--- a/src/app/tutorial/chapters/appendixB/appendixB.component.html
+++ b/src/app/tutorial/chapters/appendixB/appendixB.component.html
@@ -16,7 +16,7 @@
   <h3><a name="Red_Colors"></a>Red Colors</h3>
   <table style="background-color: #d3d3d3;">
       <tbody>
-          <tr style="color: white; background-color: #cd5c5c;">
+          <tr style="color: black; background-color: #cd5c5c;">
               <td style="width: 160px;">IndianRed</td>
               <td style="width: 80px;">#CD5C5C</td>
           </tr>
@@ -40,7 +40,7 @@
               <td style="width: 160px;">Crimson</td>
               <td style="width: 80px;">#DC143C</td>
           </tr>
-          <tr style="color: white; background-color: red;">
+          <tr style="color: black; background-color: red;">
               <td style="width: 160px;">Red</td>
               <td style="width: 80px;">#FF0000</td>
           </tr>
@@ -66,11 +66,11 @@
               <td style="width: 160px;">LightPink</td>
               <td style="width: 80px;">#FFB6C1</td>
           </tr>
-          <tr style="color: white; background-color: #ff69b4;">
+          <tr style="color: black; background-color: #ff69b4;">
               <td style="width: 160px;">HotPink</td>
               <td style="width: 80px;">#FF69B4</td>
           </tr>
-          <tr style="color: white; background-color: #ff1493;">
+          <tr style="color: black; background-color: #ff1493;">
               <td style="width: 160px;">DeepPink</td>
               <td style="width: 80px;">#FF1493</td>
           </tr>
@@ -78,7 +78,7 @@
               <td style="width: 160px;">MediumVioletRed</td>
               <td style="width: 80px;">#C71585</td>
           </tr>
-          <tr style="color: white; background-color: #db7093;">
+          <tr style="color: black; background-color: #db7093;">
               <td style="width: 160px;">PaleVioletRed</td>
               <td style="width: 80px;">#DB7093</td>
           </tr>
@@ -92,23 +92,23 @@
               <td style="width: 160px;">LightSalmon</td>
               <td style="width: 80px;">#FFA07A</td>
           </tr>
-          <tr style="color: white; background-color: #ff7f50;">
+          <tr style="color: black; background-color: #ff7f50;">
               <td style="width: 160px;">Coral</td>
               <td style="width: 80px;">#FF7F50</td>
           </tr>
-          <tr style="color: white; background-color: #ff6347;">
+          <tr style="color: black; background-color: #ff6347;">
               <td style="width: 160px;">Tomato</td>
               <td style="width: 80px;">#FF6347</td>
           </tr>
-          <tr style="color: white; background-color: #ff4500;">
+          <tr style="color: black; background-color: #ff4500;">
               <td style="width: 160px;">OrangeRed</td>
               <td style="width: 80px;">#FF4500</td>
           </tr>
-          <tr style="color: white; background-color: #ff8c00;">
+          <tr style="color: black; background-color: #ff8c00;">
               <td style="width: 160px;">DarkOrange</td>
               <td style="width: 80px;">#FF8C00</td>
           </tr>
-          <tr style="color: white; background-color: orange;">
+          <tr style="color: black; background-color: orange;">
               <td style="width: 160px;">Orange</td>
               <td style="width: 80px;">#FFA500</td>
           </tr>
@@ -158,7 +158,7 @@
               <td style="width: 160px;">Khaki</td>
               <td style="width: 80px;">#F0E68C</td>
           </tr>
-          <tr style="color: white; background-color: #bdb76b;">
+          <tr style="color: black; background-color: #bdb76b;">
               <td style="width: 160px;">DarkKhaki</td>
               <td style="width: 80px;">#BDB76B</td>
           </tr>
@@ -172,35 +172,35 @@
               <td style="width: 160px;">Lavender</td>
               <td style="width: 80px;">#E6E6FA</td>
           </tr>
-          <tr style="color: white; background-color: #d8bfd8;">
+          <tr style="color: black; background-color: #d8bfd8;">
               <td style="width: 160px;">Thistle</td>
               <td style="width: 80px;">#D8BFD8</td>
           </tr>
-          <tr style="color: white; background-color: #dda0dd;">
+          <tr style="color: black; background-color: #dda0dd;">
               <td style="width: 160px;">Plum</td>
               <td style="width: 80px;">#DDA0DD</td>
           </tr>
-          <tr style="color: white; background-color: #ee82ee;">
+          <tr style="color: black; background-color: #ee82ee;">
               <td style="width: 160px;">Violet</td>
               <td style="width: 80px;">#EE82EE</td>
           </tr>
-          <tr style="color: white; background-color: #da70d6;">
+          <tr style="color: black; background-color: #da70d6;">
               <td style="width: 160px;">Orchid</td>
               <td style="width: 80px;">#DA70D6</td>
           </tr>
-          <tr style="color: white; background-color: fuchsia;">
+          <tr style="color: black; background-color: fuchsia;">
               <td style="width: 160px;">Fuchsia</td>
               <td style="width: 80px;">#FF00FF</td>
           </tr>
-          <tr style="color: white; background-color: #ff00ff;">
+          <tr style="color: black; background-color: #ff00ff;">
               <td style="width: 160px;">Magenta</td>
               <td style="width: 80px;">#FF00FF</td>
           </tr>
-          <tr style="color: white; background-color: #ba55d3;">
+          <tr style="color: black; background-color: #ba55d3;">
               <td style="width: 160px;">MediumOrchid</td>
               <td style="width: 80px;">#BA55D3</td>
           </tr>
-          <tr style="color: white; background-color: #9370db;">
+          <tr style="color: black; background-color: #9370db;">
               <td style="width: 160px;">MediumPurple</td>
               <td style="width: 80px;">#9370DB</td>
           </tr>
@@ -236,7 +236,7 @@
               <td style="width: 160px;">DarkSlateBlue</td>
               <td style="width: 80px;">#483D8B</td>
           </tr>
-          <tr style="color: white; background-color: #7b68ee;">
+          <tr style="color: black; background-color: #7b68ee;">
               <td style="width: 160px;">MediumSlateBlue</td>
               <td style="width: 80px;">#7B68EE</td>
           </tr>
@@ -282,15 +282,15 @@
               <td style="width: 160px;">SpringGreen</td>
               <td style="width: 80px;">#00FF7F</td>
           </tr>
-          <tr style="color: white; background-color: #3cb371;">
+          <tr style="color: black; background-color: #3cb371;">
               <td style="width: 160px;">MediumSeaGreen</td>
               <td style="width: 80px;">#3CB371</td>
           </tr>
-          <tr style="color: white; background-color: #2e8b57;">
+          <tr style="color: black; background-color: #2e8b57;">
               <td style="width: 160px;">SeaGreen</td>
               <td style="width: 80px;">#2E8B57</td>
           </tr>
-          <tr style="color: white; background-color: #228b22;">
+          <tr style="color: black; background-color: #228b22;">
               <td style="width: 160px;">ForestGreen</td>
               <td style="width: 80px;">#228B22</td>
           </tr>
@@ -302,15 +302,15 @@
               <td style="width: 160px;">DarkGreen</td>
               <td style="width: 80px;">#006400</td>
           </tr>
-          <tr style="color: white; background-color: #9acd32;">
+          <tr style="color: black; background-color: #9acd32;">
               <td style="width: 160px;">YellowGreen</td>
               <td style="width: 80px;">#9ACD32</td>
           </tr>
-          <tr style="color: white; background-color: #6b8e23;">
+          <tr style="color: black; background-color: #6b8e23;">
               <td style="width: 160px;">OliveDrab</td>
               <td style="width: 80px;">#6B8E23</td>
           </tr>
-          <tr style="color: white; background-color: olive;">
+          <tr style="color: black; background-color: olive;">
               <td style="width: 160px;">Olive</td>
               <td style="width: 80px;">#808000</td>
           </tr>
@@ -322,15 +322,15 @@
               <td style="width: 160px;">MediumAquamarine</td>
               <td style="width: 80px;">#66CDAA</td>
           </tr>
-          <tr style="color: white; background-color: #8fbc8f;">
+          <tr style="color: black; background-color: #8fbc8f;">
               <td style="width: 160px;">DarkSeaGreen</td>
               <td style="width: 80px;">#8FBC8F</td>
           </tr>
-          <tr style="color: white; background-color: #20b2aa;">
+          <tr style="color: black; background-color: #20b2aa;">
               <td style="width: 160px;">LightSeaGreen</td>
               <td style="width: 80px;">#20B2AA</td>
           </tr>
-          <tr style="color: white; background-color: #008b8b;">
+          <tr style="color: black; background-color: #008b8b;">
               <td style="width: 160px;">DarkCyan</td>
               <td style="width: 80px;">#008B8B</td>
           </tr>
@@ -368,19 +368,19 @@
               <td style="width: 160px;">Turquoise</td>
               <td style="width: 80px;">#40E0D0</td>
           </tr>
-          <tr style="color: white; background-color: #48d1cc;">
+          <tr style="color: black; background-color: #48d1cc;">
               <td style="width: 160px;">MediumTurquoise</td>
               <td style="width: 80px;">#48D1CC</td>
           </tr>
-          <tr style="color: white; background-color: #00ced1;">
+          <tr style="color: black; background-color: #00ced1;">
               <td style="width: 160px;">DarkTurquoise</td>
               <td style="width: 80px;">#00CED1</td>
           </tr>
-          <tr style="color: white; background-color: #5f9ea0;">
+          <tr style="color: black; background-color: #5f9ea0;">
               <td style="width: 160px;">CadetBlue</td>
               <td style="width: 80px;">#5F9EA0</td>
           </tr>
-          <tr style="color: white; background-color: #4682b4;">
+          <tr style="color: black; background-color: #4682b4;">
               <td style="width: 160px;">SteelBlue</td>
               <td style="width: 80px;">#4682B4</td>
           </tr>
@@ -404,19 +404,19 @@
               <td style="width: 160px;">LightSkyBlue</td>
               <td style="width: 80px;">#87CEFA</td>
           </tr>
-          <tr style="color: white; background-color: #00bfff;">
+          <tr style="color: black; background-color: #00bfff;">
               <td style="width: 160px;">DeepSkyBlue</td>
               <td style="width: 80px;">#00BFFF</td>
           </tr>
-          <tr style="color: white; background-color: #1e90ff;">
+          <tr style="color: black; background-color: #1e90ff;">
               <td style="width: 160px;">DodgerBlue</td>
               <td style="width: 80px;">#1E90FF</td>
           </tr>
-          <tr style="color: white; background-color: #6495ed;">
+          <tr style="color: black; background-color: #6495ed;">
               <td style="width: 160px;">CornflowerBlue</td>
               <td style="width: 80px;">#6495ED</td>
           </tr>
-          <tr style="color: white; background-color: #7b68ee;">
+          <tr style="color: black; background-color: #7b68ee;">
               <td style="width: 160px;">MediumSlateBlue</td>
               <td style="width: 80px;">#7B68EE</td>
           </tr>
@@ -470,35 +470,35 @@
               <td style="width: 160px;">Wheat</td>
               <td style="width: 80px;">#F5DEB3</td>
           </tr>
-          <tr style="color: white; background-color: #deb887;">
+          <tr style="color: black; background-color: #deb887;">
               <td style="width: 160px;">BurlyWood</td>
               <td style="width: 80px;">#DEB887</td>
           </tr>
-          <tr style="color: white; background-color: #d2b48c;">
+          <tr style="color: black; background-color: #d2b48c;">
               <td style="width: 160px;">Tan</td>
               <td style="width: 80px;">#D2B48C</td>
           </tr>
-          <tr style="color: white; background-color: #bc8f8f;">
+          <tr style="color: black; background-color: #bc8f8f;">
               <td style="width: 160px;">RosyBrown</td>
               <td style="width: 80px;">#BC8F8F</td>
           </tr>
-          <tr style="color: white; background-color: #f4a460;">
+          <tr style="color: black; background-color: #f4a460;">
               <td style="width: 160px;">SandyBrown</td>
               <td style="width: 80px;">#F4A460</td>
           </tr>
-          <tr style="color: white; background-color: #daa520;">
+          <tr style="color: black; background-color: #daa520;">
               <td style="width: 160px;">Goldenrod</td>
               <td style="width: 80px;">#DAA520</td>
           </tr>
-          <tr style="color: white; background-color: #b8860b;">
+          <tr style="color: black; background-color: #b8860b;">
               <td style="width: 160px;">DarkGoldenrod</td>
               <td style="width: 80px;">#B8860B</td>
           </tr>
-          <tr style="color: white; background-color: #cd853f;">
+          <tr style="color: black; background-color: #cd853f;">
               <td style="width: 160px;">Peru</td>
               <td style="width: 80px;">#CD853F</td>
           </tr>
-          <tr style="color: white; background-color: #d2691e;">
+          <tr style="color: black; background-color: #d2691e;">
               <td style="width: 160px;">Chocolate</td>
               <td style="width: 80px;">#D2691E</td>
           </tr>
@@ -614,7 +614,7 @@
               <td style="width: 160px;">DarkGray</td>
               <td style="width: 80px;">#A9A9A9</td>
           </tr>
-          <tr style="color: white; background-color: gray;">
+          <tr style="color: black; background-color: gray;">
               <td style="width: 160px;">Gray</td>
               <td style="width: 80px;">#808080</td>
           </tr>
@@ -622,11 +622,11 @@
               <td style="width: 160px;">DimGray</td>
               <td style="width: 80px;">#696969</td>
           </tr>
-          <tr style="color: white; background-color: #778899;">
+          <tr style="color: black; background-color: #778899;">
               <td style="width: 160px;">LightSlateGray</td>
               <td style="width: 80px;">#778899</td>
           </tr>
-          <tr style="color: white; background-color: #708090;">
+          <tr style="color: black; background-color: #708090;">
               <td style="width: 160px;">SlateGray</td>
               <td style="width: 80px;">#708090</td>
           </tr>


### PR DESCRIPTION
Fixes #75 

Changed black text to white (or white text to black) to pass accessibility color contrast rules as detected by Accessibility Insights.

Top of color list after the changes:
![image](https://user-images.githubusercontent.com/1752950/61821753-d6e9d500-ae0c-11e9-85f3-cb6a7ea0956e.png)
